### PR TITLE
fix: vercel deployment cannot find bootstrap

### DIFF
--- a/components/BootstrapInput.js
+++ b/components/BootstrapInput.js
@@ -1,5 +1,5 @@
 import { Form } from "react-bootstrap";
-import styles from "../../styles/BootstrapInput.module.css";
+import styles from "../styles/BootstrapInput.module.css";
 
 export const BootstrapInput = ({
   controlId,


### PR DESCRIPTION
The Vercel Deployment is breaking because it cannot find the imported module