### PR TITLE
Fix: aws-deployment npm ci and kill by port

### DIFF
--- a/scripts/application_start.sh
+++ b/scripts/application_start.sh
@@ -8,6 +8,6 @@ export NVM_DIR="$HOME/.nvm"
 cd /home/ec2-user/next-app
 
 #install node modules
-npm install
+npm ci
 npm run build
-npm start > app.out.log 2> app.err.log < /dev/null & 
+npm start -- -p 3000> app.out.log 2> app.err.log < /dev/null & 

--- a/scripts/application_stop.sh
+++ b/scripts/application_stop.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Stopping application"
-pkill node || true
+kill -9 $(lsof -i:3000 -t) || true


### PR DESCRIPTION
All future deployments use npm ci and kill process by port instead of by name