### PR TITLE
Fix: npm ci uses too much ram, leading to system deadlock

### DIFF
--- a/scripts/application_start.sh
+++ b/scripts/application_start.sh
@@ -8,6 +8,6 @@ export NVM_DIR="$HOME/.nvm"
 cd /home/ec2-user/next-app
 
 #install node modules
-npm ci
+yarn install --frozen-lockfile || true
 npm run build
 npm start -- -p 3000 > app.out.log 2> app.err.log < /dev/null & 


### PR DESCRIPTION
Switch to using yarn to install packages instead, still uses npm to run project