### PR TITLE
fix: group size init

### DIFF
--- a/components/AdminOverview.js
+++ b/components/AdminOverview.js
@@ -46,7 +46,8 @@ const AdminOverview = (props) => {
               topicsData: data["result"][0].topics,
             });
           }
-          setGroupSize(data["result"][0]?.groupConfiguration?.groupSize);
+          data["result"][0]?.groupConfiguration?.groupSize &&
+            setGroupSize(data["result"][0]?.groupConfiguration?.groupSize);
           setTutorial(data["result"][0]);
         }
       });
@@ -128,7 +129,7 @@ const AdminOverview = (props) => {
                 <StudentOverviewTable
                   students={students}
                   studentGroups={groups}
-                  tutorialId = {tutorialId}
+                  tutorialId={tutorialId}
                 />
               </div>
             </Tab>


### PR DESCRIPTION
Quick fix for initializing the group size if a tutorial does not already have a saved group configuration.